### PR TITLE
Enable repoadmin REST when tests override svn-httpd image conf

### DIFF
--- a/test/conf-svn/cgi/00load.conf
+++ b/test/conf-svn/cgi/00load.conf
@@ -1,0 +1,6 @@
+<IfModule !mpm_prefork_module>
+	LoadModule cgid_module modules/mod_cgid.so
+</IfModule>
+<IfModule mpm_prefork_module>
+	LoadModule cgi_module modules/mod_cgi.so
+</IfModule>

--- a/test/conf-svn/cgi/admin.conf
+++ b/test/conf-svn/cgi/admin.conf
@@ -1,0 +1,8 @@
+
+ScriptAlias "/admin/" "/usr/local/apache2/admin-cgi/"
+
+<Directory /usr/local/apache2/admin-cgi>
+  Options +ExecCGI
+  Require all granted
+  PassEnv ADMIN_REST_ACCESS
+</Directory>

--- a/test/conf-svn/httpd.conf
+++ b/test/conf-svn/httpd.conf
@@ -1,4 +1,5 @@
 Include conf/svn/load.conf
+Include conf/svn/cgi/*.conf
 
 <Location /svn>
   DAV svn


### PR DESCRIPTION
From https://github.com/Reposoft/docker-svn/pull/5

Ideally we'd have an svn docker image that doesn't require a mounted conf. Granted this is for testing though.
