### PR TITLE
Handle folder targets with no trailing slash, using redirect

### DIFF
--- a/repos-web/account/login.inc.php
+++ b/repos-web/account/login.inc.php
@@ -163,7 +163,13 @@ function _login_getParentUrl($url) {
  * Note that this can not handle old revisions of folders that have been deleted.
  */
 function login_followRedirect($fromUrl, $headers) {
-	$location = rawurldecode($headers['Location']);  // location header is urlencoded
+	$locationHeader = $headers['Location'];
+	$locationQuery = strAfter($locationHeader, '?');
+	if ($locationQuery) {
+		if ($locationQuery != 'serv=json') return;
+		$locationHeader = substr($locationHeader, 0, strlen($locationHeader) - strlen($locationQuery) - 1);
+	}
+	$location = rawurldecode($locationHeader);  // location header is urlencoded
 	$from = substr($fromUrl, strlen(getRepository()));
 	$to = substr($location, strlen(getRepository()));
 	$url = getSelfUrl().'?'.getSelfQuery();

--- a/repos-web/edit/upload/index.php
+++ b/repos-web/edit/upload/index.php
@@ -5,6 +5,9 @@
  */
 require(dirname(dirname(dirname(__FILE__))).'/conf/Presentation.class.php');
 require(dirname(dirname(__FILE__)).'/SvnEdit.class.php');
+
+targetLogin(); // edit operation can not be public
+
 require(dirname(dirname(dirname(__FILE__))).'/open/getlog.php');
 require(dirname(__FILE__).'/filewrite.inc.php');
 

--- a/repos-web/open/index.php
+++ b/repos-web/open/index.php
@@ -23,8 +23,6 @@ $fromrevRule = new RevisionRule('fromrev');
 $fromrev = $fromrevRule->getValue();
 
 $file = new SvnOpenFile($target, $rev);
-// identify folders, even without trailing slash, for example when coming from history
-$isFoler = $file->isFolder();
 
 // support redirect directly to real resorce (for services that don't know repository root but have target and base)
 if (isset($_GET['redirect']) && $_GET['redirect']) {

--- a/repos-web/open/index.php
+++ b/repos-web/open/index.php
@@ -47,7 +47,7 @@ if (isset($_GET['redirect']) && $_GET['redirect']) {
 $p = Presentation::getInstance();
 $p->assign_by_ref('file', $file);
 // for links to other operations we use the original parameters
-$p->assign('target', getTarget());
+$p->assign('target', $target);
 if ($fromrev) $p->assign('fromrev', $fromrev);
 // display a short log for the file on the edit page
 if (!isset($_REQUEST['history']) || $_REQUEST['history'] != 'false') {

--- a/repos-web/open/index.php
+++ b/repos-web/open/index.php
@@ -25,12 +25,12 @@ $fromrev = $fromrevRule->getValue();
 $file = new SvnOpenFile($target, $rev);
 // identify folders, even without trailing slash, for example when coming from history
 $isFoler = $file->isFolder();
-// for old revisions SvnOpenFile detects folder even if trailing slash is missing
-if (!strEnds($target, '/')) $target .= '/';
 
 // support redirect directly to real resorce (for services that don't know repository root but have target and base)
 if (isset($_GET['redirect']) && $_GET['redirect']) {
 	if ($rev) {
+		// for old revisions SvnOpenFile detects folder even if trailing slash is missing
+		if (!strEnds($target, '/')) $target .= '/';
 		// does not use getRepository so "base" must be added manually
 		$b = isset($_REQUEST['base']) ? '&base='.$_REQUEST['base'] : '';
 		header('Location: '.getWebapp().'open/list/?target='.rawurlencode($target).$b.'&rev='.$rev);
@@ -49,7 +49,7 @@ if (isset($_GET['redirect']) && $_GET['redirect']) {
 $p = Presentation::getInstance();
 $p->assign_by_ref('file', $file);
 // for links to other operations we use the original parameters
-$p->assign('target', $target);
+$p->assign('target', getTarget());
 if ($fromrev) $p->assign('fromrev', $fromrev);
 // display a short log for the file on the edit page
 if (!isset($_REQUEST['history']) || $_REQUEST['history'] != 'false') {


### PR DESCRIPTION
Reverts #12 and attempts a fix to the same problem with less risk of regressions. This revert fixes #16.