### PR TITLE
Support Ubuntu Bionic without pdftk

### DIFF
--- a/repos-plugins/thumbnails/convert/graphicstransforms.inc.php
+++ b/repos-plugins/thumbnails/convert/graphicstransforms.inc.php
@@ -143,7 +143,7 @@ class ReposGraphicsTransformExtract extends ReposGraphicsTransformBase {
 		}
 		$page = $_REQUEST['page'];
 		unset($_REQUEST['page']); // disable default page handling
-		return 'pdftk - cat '.$page.' output "'.$tempfile.'"';
+		return 'gs -dBATCH -dNOPAUSE -sOutputFile="'.$tempfile.'" -dFirstPage='.$page.' -dLastPage='.$page.' -sDEVICE=pdfwrite -';
 	}
 
 }


### PR DESCRIPTION
Fixes #29. Ghostscript is already a dependency of GraphicsMagick, so this shouldn't require any additional packages.