### PR TITLE
Restore tree plugin for use with Copy, Move, Rename

### DIFF
--- a/repos-plugins/tree/tree.load.js
+++ b/repos-plugins/tree/tree.load.js
@@ -85,10 +85,11 @@ $.fn.reposTree = function( options ) {
 		var list = $('#' + id);
 		var here = target;
 		$.ajax({
-			dataType : 'script',
+			dataType : 'text',
 			url : json + '?selector=' + id + '&target=' + encodeURI(here)
 					+ (settings.base ? '&base=' + settings.base : ''),
-			success : function() {
+			success : function(script) {
+				$.globalEval(script);
 				// list item has the expand/collapse logic
 				var added = $('> li', list);
 				if (settings.startpath) {

--- a/repos-web/open/json/index.php
+++ b/repos-web/open/json/index.php
@@ -29,16 +29,17 @@ $rev = $revisionRule->getValue();
 
 $json = getListJson($url, $rev);
 
-// javascript output
-header('Content-Type: text/plain');
 header('Cache-Control: max-age=0, must-revalidate'); // IE9 does too aggressive caching by default in AJAX requests
 
 // second part of the script is printed if there is a selector
 if (!isset($_GET['selector'])) {
+	header('Content-Type: application/json');
 	header('Content-Length: '.strlen($json));
 	echo($json);
 	exit;
 } else {
+	// javascript output
+	header('Content-Type: text/plain;charset=utf-8');
 	// put the data in a variable for the bundled script below
 	// the data must be included in the script to allow cross-domain listings
 	$json = 'var svn = '.$json.';';

--- a/repos-web/open/json/index.php
+++ b/repos-web/open/json/index.php
@@ -39,7 +39,7 @@ if (!isset($_GET['selector'])) {
 	exit;
 } else {
 	// javascript output
-	header('Content-Type: text/plain;charset=utf-8');
+	header('Content-Type: application/javascript;charset=UTF-8');
 	// put the data in a variable for the bundled script below
 	// the data must be included in the script to allow cross-domain listings
 	$json = 'var svn = '.$json.';';

--- a/repos-web/scripts/build-arbortext.bat
+++ b/repos-web/scripts/build-arbortext.bat
@@ -1,2 +1,2 @@
 echo "Excluding plugins that are not in the standard package"
-ant -Dplugins.excludes="refresh/**,jquery.jqUploader/**,admin*/**,linehistory/**,templates/**,tinymce/**,loginconventional/**,sla/**,listrecursive/**,thumblist/**,tree/**"
+ant -Dplugins.excludes="refresh/**,jquery.jqUploader/**,admin*/**,linehistory/**,templates/**,tinymce/**,loginconventional/**,sla/**,listrecursive/**,thumblist/**"

--- a/repos-web/scripts/build-defaultexcludes.bat
+++ b/repos-web/scripts/build-defaultexcludes.bat
@@ -1,2 +1,2 @@
 echo "Excluding plugins that are not in the standard package"
-ant -Dplugins.excludes="refresh/**,jquery.jqUploader/**,admin*/**,linehistory/**,templates/**,tinymce/**,loginconventional/**,sla/**,listrecursive/**,thumblist/**,tree/**"
+ant -Dplugins.excludes="refresh/**,jquery.jqUploader/**,admin*/**,linehistory/**,templates/**,tinymce/**,loginconventional/**,sla/**,listrecursive/**,thumblist/**"


### PR DESCRIPTION
Fixes regression with Select Destination Folder, #33. This was the only place where we used jQuery's `dataType` = `script`. The javascript returned from `/repos-web/open/json/?selector=...&target=/...` is still valid for eval.

Also changes the `Content-Type` of `/repos-web/open/json/` (without selector) to `application/json`. That's the straightforward folder listing.