### PR TITLE
Uses proper XML parsing and JSON encoding for endpoint open/json/

### DIFF
--- a/repos-web/open/json/index.php
+++ b/repos-web/open/json/index.php
@@ -42,7 +42,7 @@ if (!isset($_GET['selector'])) {
 	header('Content-Type: application/javascript;charset=UTF-8');
 	// put the data in a variable for the bundled script below
 	// the data must be included in the script to allow cross-domain listings
-	$json = 'var svn = '.$json.';';
+	$json = 'var svn = '.$json.';'."\n";
 }
 
 // import configuration from query string to settings json object


### PR DESCRIPTION
Fixes #47

Comes with a risk of regression as the rendered JSON might differ from what the original xml->json would produce.

A known difference is that the new JSON includes a `name` property for each entry, in addition to using name as map key like the old format did.

Also I haven't evaluated if more flags to [PHP's json_encode](https://www.php.net/manual/en/function.json-encode.php) would take us closer to the original. There were some surprising defaults (like escaped forward slashes) that I [got rid of](https://github.com/Reposoft/rweb/blob/43fb96b36c932452eca071e1afab23e428b0df72/repos-web/open/json/listjson.php#L130).

We now depend on PHP 7.3+. Ok?

@takesson Let me know if you need a proper beta release to test this. I've tested manually using the docker-compose stack. To compare outputs you can switch between an installed listjson.php and [the one from this PR](https://github.com/Reposoft/rweb/raw/listjson-xml-parser/repos-web/open/json/listjson.php).